### PR TITLE
Add charset and viewport meta tags for browsers

### DIFF
--- a/layouts/partials/wtg-shell/output/head-contents.html
+++ b/layouts/partials/wtg-shell/output/head-contents.html
@@ -4,6 +4,8 @@
 {{- else }}
 <title>{{ partialCached "wtg-shell/helpers/find-page-title.html" . . | safeHTML }}</title>
 {{- end }}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
 {{ hugo.Generator }}
 {{- if templates.Exists "partials/wtg-theme/output/head-css.html" -}}
 	{{- partialCached "wtg-theme/output/head-css.html" . . -}}


### PR DESCRIPTION
Informing the browser of utf-8 and the viewport go a long way to having the expected experience.