### PR TITLE
Add hook in 'head' for a JS processing template

### DIFF
--- a/layouts/partials/wtg-shell/output/head-contents.html
+++ b/layouts/partials/wtg-shell/output/head-contents.html
@@ -12,6 +12,13 @@
 {{- else -}}
 	{{- partialCached "wtg-shell/output/head-css.html" . . -}}
 {{- end -}}
+{{- if templates.Exists "partials/wtg-theme/output/head-js.html" -}}
+	{{- partialCached "wtg-theme/output/head-js.html" . . -}}
+{{- else -}}
+	{{- if templates.Exists "partials/wtg-shell/output/head-js.html" -}}
+		{{- partialCached "wtg-shell/output/head-js.html" . . -}}
+	{{- end -}}
+{{- end -}}
 {{- if templates.Exists "partials/wtg-theme/output/head-metadata.html" -}}
 	{{- partialCached "wtg-theme/output/head-metadata.html" . . -}}
 {{- else -}}


### PR DESCRIPTION
We don't actually do any JS processing yet, because we don't have JS
on the site (yet).

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>